### PR TITLE
pushed import statements to top of the file

### DIFF
--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -4,6 +4,13 @@ import pytest
 
 import flask
 
+from config_module_app import app as config_module_app
+from config_package_app import app as config_package_app
+from namespace.package2 import app as namespace_package2_app
+from site_app import app as site_app
+from installed_package import app as installed_package_app
+import site_package as site_package
+
 
 def test_explicit_instance_paths(modules_tmp_path):
     with pytest.raises(ValueError, match=".*must be absolute"):
@@ -22,9 +29,8 @@ def test_uninstalled_module_paths(modules_tmp_path, purge_module):
     )
     purge_module("config_module_app")
 
-    from config_module_app import app
-
-    assert app.instance_path == os.fspath(modules_tmp_path / "instance")
+    assert config_module_app.instance_path == os.fspath(modules_tmp_path / "instance")
+    
 
 
 def test_uninstalled_package_paths(modules_tmp_path, purge_module):
@@ -38,9 +44,7 @@ def test_uninstalled_package_paths(modules_tmp_path, purge_module):
     )
     purge_module("config_package_app")
 
-    from config_package_app import app
-
-    assert app.instance_path == os.fspath(modules_tmp_path / "instance")
+    assert config_package_app.instance_path == os.fspath(modules_tmp_path / "instance")
 
 
 def test_uninstalled_namespace_paths(tmp_path, monkeypatch, purge_module):
@@ -57,9 +61,7 @@ def test_uninstalled_namespace_paths(tmp_path, monkeypatch, purge_module):
     purge_module("namespace.package2")
     purge_module("namespace")
 
-    from namespace.package2 import app
-
-    assert app.instance_path == os.fspath(project2 / "instance")
+    assert namespace_package2_app.instance_path == os.fspath(project2 / "instance")
 
 
 def test_installed_module_paths(
@@ -70,9 +72,7 @@ def test_installed_module_paths(
     )
     purge_module("site_app")
 
-    from site_app import app
-
-    assert app.instance_path == os.fspath(
+    assert site_app.instance_path == os.fspath(
         modules_tmp_path / "var" / "site_app-instance"
     )
 
@@ -89,9 +89,7 @@ def test_installed_package_paths(
     (app / "__init__.py").write_text("import flask\napp = flask.Flask(__name__)\n")
     purge_module("installed_package")
 
-    from installed_package import app
-
-    assert app.instance_path == os.fspath(
+    assert installed_package_app.instance_path == os.fspath(
         modules_tmp_path / "var" / "installed_package-instance"
     )
 
@@ -104,7 +102,7 @@ def test_prefix_package_paths(
     (app / "__init__.py").write_text("import flask\napp = flask.Flask(__name__)\n")
     purge_module("site_package")
 
-    import site_package
+
 
     assert site_package.app.instance_path == os.fspath(
         modules_tmp_path / "var" / "site_package-instance"

--- a/tests/test_instance_config.py
+++ b/tests/test_instance_config.py
@@ -4,12 +4,12 @@ import pytest
 
 import flask
 
-from config_module_app import app as config_module_app
-from config_package_app import app as config_package_app
-from namespace.package2 import app as namespace_package2_app
+from config_module_app import app as mod_app
+from config_package_app import app as pck_app
+from namespace.package2 import app as ns_pkg2_app
 from site_app import app as site_app
-from installed_package import app as installed_package_app
-import site_package as site_package
+from installed_package import app as inst_pkg_app
+import site_package as site_pkg
 
 
 def test_explicit_instance_paths(modules_tmp_path):
@@ -29,7 +29,7 @@ def test_uninstalled_module_paths(modules_tmp_path, purge_module):
     )
     purge_module("config_module_app")
 
-    assert config_module_app.instance_path == os.fspath(modules_tmp_path / "instance")
+    assert mod_app.instance_path == os.fspath(modules_tmp_path / "instance")
     
 
 
@@ -44,7 +44,7 @@ def test_uninstalled_package_paths(modules_tmp_path, purge_module):
     )
     purge_module("config_package_app")
 
-    assert config_package_app.instance_path == os.fspath(modules_tmp_path / "instance")
+    assert pck_app.instance_path == os.fspath(modules_tmp_path / "instance")
 
 
 def test_uninstalled_namespace_paths(tmp_path, monkeypatch, purge_module):
@@ -61,7 +61,7 @@ def test_uninstalled_namespace_paths(tmp_path, monkeypatch, purge_module):
     purge_module("namespace.package2")
     purge_module("namespace")
 
-    assert namespace_package2_app.instance_path == os.fspath(project2 / "instance")
+    assert ns_pkg2_app.instance_path == os.fspath(project2 / "instance")
 
 
 def test_installed_module_paths(
@@ -89,7 +89,7 @@ def test_installed_package_paths(
     (app / "__init__.py").write_text("import flask\napp = flask.Flask(__name__)\n")
     purge_module("installed_package")
 
-    assert installed_package_app.instance_path == os.fspath(
+    assert inst_pkg_app.instance_path == os.fspath(
         modules_tmp_path / "var" / "installed_package-instance"
     )
 
@@ -104,6 +104,6 @@ def test_prefix_package_paths(
 
 
 
-    assert site_package.app.instance_path == os.fspath(
+    assert site_pkg.app.instance_path == os.fspath(
         modules_tmp_path / "var" / "site_package-instance"
     )


### PR DESCRIPTION
removed import statements from test functions and placed them all on top, gave them separate names using the "import as" keyword, and called them again inside each function.